### PR TITLE
Fixes Stackoverflow Issue

### DIFF
--- a/src/main/scala/TreeF.scala
+++ b/src/main/scala/TreeF.scala
@@ -1,28 +1,43 @@
-import cats.Functor
-import qq.droste.Coalgebra
+import cats.implicits._
+import cats.{Applicative, Traverse}
+import qq.droste.util.DefaultTraverse
+import qq.droste.{Algebra, Basis, Coalgebra}
 
 sealed trait TreeF[A]
+
 object TreeF {
+
   final case class BranchF[A](left: A, right: A) extends TreeF[A]
-  final case class StringNodeF[A]() extends TreeF[A]
-  final case class RepeatNode[A](valueToRepeat: A) extends TreeF[A]
 
-  implicit val treeFFunctor: Functor[TreeF] = new Functor[TreeF] {
-    override def map[A, B](fa: TreeF[A])(f: A => B): TreeF[B] = fa match {
-      case StringNodeF()      => StringNodeF()
-      case RepeatNode(value)  => RepeatNode(f(value))
-      case BranchF(l, r)      => BranchF(f(l), f(r))
+  final case class StringNodeF[A](a: String) extends TreeF[A]
+
+  final case class RepeatNodeF[A](valueToRepeat: String) extends TreeF[A]
+
+  implicit val traverseExprF: Traverse[TreeF] =
+    new DefaultTraverse[TreeF] {
+      def traverse[G[_]: Applicative, A, B](fa: TreeF[A])(f: A => G[B]): G[TreeF[B]] =
+        fa match {
+          case c: StringNodeF[B] => (c: TreeF[B]).pure[G]
+          case c: RepeatNodeF[B] => (c: TreeF[B]).pure[G]
+          case BranchF(l, r) => (f(l), f(r)).mapN(BranchF(_, _))
+        }
     }
+
+  val embedAlgebra: Algebra[TreeF, Tree] = Algebra {
+    case StringNodeF(v) => Node(v, false)
+    case RepeatNodeF(a) => Node(a, true)
+    case BranchF(l, r) => Branch(l, r)
   }
 
-  def fromTree: Coalgebra[TreeF, Tree] = Coalgebra { tree: Tree =>
-    tree match {
-      case Branch(l,r) => BranchF(l, r)
-      // Herein lies the problem. Either stack overflow or unreachable code.
-      case n: Node if n.repeats => RepeatNode(n)
-      case _: Node => StringNodeF()
-    }
+  val fromTree: Coalgebra[TreeF, Tree] = Coalgebra {
+    case Branch(l, r) => BranchF(l, r)
+    case n: Node if n.repeats => RepeatNodeF(n.value)
+    case n: Node => StringNodeF(n.value)
   }
+
+
+  implicit val basisExprF: Basis[TreeF, Tree] =
+    Basis.Default(embedAlgebra, fromTree)
 }
 
 

--- a/src/main/scala/print.scala
+++ b/src/main/scala/print.scala
@@ -1,20 +1,20 @@
 import qq.droste.{Algebra, Basis, scheme}
 import TreeF._
+
 trait Printer[A] {
   def print(a: A): String
+
   def contramap[B](f: B => A): Printer[B] = Printer(f.andThen(print))
 }
 
 object Printer {
   def apply[A](f: A => String): Printer[A] = (a: A) => f(a)
 
-  def printSchema[T: Basis[TreeF, ?]]: Printer[T] = {
-    val algebra: Algebra[TreeF, String] = Algebra {
-    case StringNodeF() => "String"
-    case RepeatNode(_) => s"List[String]"
+  val evaluateAlgebra: Algebra[TreeF, String] = Algebra {
+    case StringNodeF(_) => "String"
+    case RepeatNodeF(_) => "List[String]"
     case BranchF(l, r) => s"Either[$l,$r]"
-    }
-
-    Printer(scheme.cata(algebra))
   }
+
+  def printSchema[T: Basis[TreeF, ?]]: Printer[T] = Printer(scheme.cata(evaluateAlgebra))
 }


### PR DESCRIPTION
This PR fixes the Stackoverflow issue. The current output would be:

```bash
[info] Running Playground
Either[Either[String,List[String]],String]
```

Basically, what I did is to re-write the `TreeF` functor in terms of `Traversable`, given the tree structure. Additionally, I defined both algebra and coalgebra of `TreeF, Tree`, and also a `qq.droste.Basis` relating them.