### PR TITLE
Flattened TreeF

### DIFF
--- a/src/main/scala/Printer.scala
+++ b/src/main/scala/Printer.scala
@@ -11,10 +11,10 @@ object Printer {
   def apply[A](f: A => String): Printer[A] = (a: A) => f(a)
 
   val evaluateAlgebra: Algebra[TreeF, String] = Algebra {
-    case PrimitiveInt() => "Int"
-    case PrimitiveString() => "String"
-    case NodeF(value) => s"$value"
-    case RepeatNodeF(value) => s"List[$value]"
+    case IntValue() => "Int"
+    case StringValue() => "String"
+    case IntList() => s"List[Int]"
+    case StringList() => s"List[String]"
     case BranchF(l, r) => s"Either[$l,$r]"
   }
 

--- a/src/main/scala/Tree.scala
+++ b/src/main/scala/Tree.scala
@@ -1,5 +1,9 @@
 // A tree of strings where the terminal case has a special annotation that we will care about modeling
 sealed trait Tree
-case class Branch(left: Tree, right: Tree) extends Tree
-case class Node(value: Either[String, Int], repeats: Boolean) extends Tree
+
+case class Branch(left: Tree,
+                  right: Tree) extends Tree
+
+case class Node(value: Either[String, Int],
+                repeats: Boolean) extends Tree
 

--- a/src/main/scala/TreeF.scala
+++ b/src/main/scala/TreeF.scala
@@ -3,26 +3,26 @@ import cats.{Applicative, Traverse}
 import qq.droste.Coalgebra
 import qq.droste.util.DefaultTraverse
 
+import scala.language.higherKinds
+
 sealed trait TreeF[A]
 
 object TreeF {
 
   final case class BranchF[A](left: A, right: A) extends TreeF[A]
-
-  final case class NodeF[A](a: A) extends TreeF[A]
-  final case class RepeatNodeF[A](valueToRepeat: A) extends TreeF[A]
-
-  final case class PrimitiveString[A]() extends TreeF[A]
-  final case class PrimitiveInt[A]() extends TreeF[A]
+  final case class StringList[A]() extends TreeF[A]
+  final case class IntList[A]() extends TreeF[A]
+  final case class StringValue[A]() extends TreeF[A]
+  final case class IntValue[A]() extends TreeF[A]
 
   implicit val traverseExprF: Traverse[TreeF] =
     new DefaultTraverse[TreeF] {
       def traverse[G[_] : Applicative, A, B](fa: TreeF[A])(f: A => G[B]): G[TreeF[B]] =
         fa match {
-          case PrimitiveInt() => (PrimitiveInt[B](): TreeF[B]).pure[G]
-          case PrimitiveString() => (PrimitiveString[B](): TreeF[B]).pure[G]
-          case RepeatNodeF(a) => f(a).map(b => RepeatNodeF(b): TreeF[B])
-          case NodeF(a) => f(a).map(b => NodeF(b): TreeF[B])
+          case IntValue() => (IntValue[B](): TreeF[B]).pure[G]
+          case IntList() => (IntList[B](): TreeF[B]).pure[G]
+          case StringValue() => (StringValue[B](): TreeF[B]).pure[G]
+          case StringList() => (StringList[B](): TreeF[B]).pure[G]
           case BranchF(l, r) => (f(l), f(r)).mapN(BranchF(_, _))
         }
     }
@@ -30,10 +30,10 @@ object TreeF {
   // Either this stack overflows, or if you change the order, you have never see the List type repeated
   val fromTree: Coalgebra[TreeF, Tree] = Coalgebra {
     case Branch(l, r) => BranchF(l, r)
-    case n: Node if n.repeats => RepeatNodeF(n)
-    case n: Node => NodeF(n)
-    case Node(Right(_), _ ) => PrimitiveInt()
-    case Node(Left(_), _ ) => PrimitiveString()
+    case Node(Right(_), true) => IntList()
+    case Node(Right(_), false) => IntValue()
+    case Node(Left(_), true ) => StringList()
+    case Node(Left(_), false ) => StringValue()
   }
 }
 


### PR DESCRIPTION
`Node` and `RepeatNode` are too generic, if you want to keep them you need to be able to turn a `Tree` into a `Node(PrimitiveInt())` in one step which I don't think is possible using `Coalgebra`